### PR TITLE
support returning promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 var argv = require('yargs').argv;
+var Bluebird = require('bluebird');
 
-function printOutput(output){
-  console.log('--------make-runnable-output--------');
-  console.log(output);
-  console.log('------------------------------------');
+function printOutput(returnValue){
+  Bluebird.resolve(returnValue)
+  .then(function (output){
+    console.log('--------make-runnable-output--------');
+    console.log(output);
+    console.log('------------------------------------');
+  });
 }
 
 function printError(error){

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/super-cache-money/make-runnable"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "yargs": "^4.7.1"
   },
   "browser": {


### PR DESCRIPTION
Fixes #5 

By passing it into [`Bluebird.resolve`](http://bluebirdjs.com/docs/api/promise.resolve.html), if it's a promise, it'll be waited on. If not, it will immediately call the `.then` callback.

I wish I could've added tests, but there are none. I did test it locally though and it seemed to work fine.